### PR TITLE
mkefi-agl.sh: fix cleanup

### DIFF
--- a/mkefi-agl.sh
+++ b/mkefi-agl.sh
@@ -64,7 +64,7 @@ cleanup() {
 	if [ -d "$TMPDIR" ]; then
 		rm -rf "$TMPDIR" || error "Failed to remove $TMPDIR"
 	fi
-        [ -f "$TMP_DIR/TMP-AGL-wic-image.wic" ] || rm -f $TMP_DIR/TMP-AGL-wic-image.wic
+        [ -f "$TMP_DIR/TMP-AGL-wic-image.wic" ] && rm -f $TMP_DIR/TMP-AGL-wic-image.wic
 }
 
 trap 'die "Signal Received, Aborting..."' HUP INT TERM


### PR DESCRIPTION
Huge extracted disk image was not removed from /tmp at the end of the script. BTW, there are two temp dirs in the script and it could be a good idea to use a unique temp dir for all ops.